### PR TITLE
实现自动部署云服务器

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: 部署到云服务器
+
+on:
+  push:
+    branches:
+      - main
+      - 'feature-*'
+
+jobs:
+  构建并部署:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v3
+      - name: 设置 Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: 安装依赖
+        run: npm ci
+        working-directory: glancy-site
+      - name: 构建项目
+        run: npm run build
+        working-directory: glancy-site
+      - name: 同步到服务器
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_KEY }}
+          source: "glancy-site/dist/*"
+          target: ${{ secrets.DEPLOY_PATH }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # Glancy 网站
 
 此仓库包含 Glancy 电子词典官网的前端代码，采用 React + Vite 构建。
+
+## 部署方式
+
+通过 GitHub Actions 自动构建并将生成的静态文件同步到云服务器。你需要在仓库的 `Settings -> Secrets and variables -> Actions` 中设置以下几个 Secret：
+
+- `DEPLOY_HOST`：服务器地址
+- `DEPLOY_USER`：登录用户名
+- `DEPLOY_KEY`：对应用户的私钥
+- `DEPLOY_PATH`：文件同步到服务器上的目标目录
+
+每次向 `main` 分支或以 `feature-` 开头的分支推送代码时，`部署到云服务器` 工作流程都会自动执行。


### PR DESCRIPTION
## Summary
- 使用 GitHub Actions 在推送到 `main` 或 `feature-*` 分支时自动构建并同步到云服务器
- 在 README 中说明部署所需的 Secrets 与流程

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872d08c658c8332bfbd7719ebc34b6f